### PR TITLE
Add custom claims example via Struct

### DIFF
--- a/docs/usage/create.md
+++ b/docs/usage/create.md
@@ -110,12 +110,12 @@ type CustomClaims struct {
 }
 
 claims := CustomClaims{ // (1)!
- "bar", // (2) !
-  jwt.RegisteredClaims{ // (3) !
+ Foo: "bar", // (2) !
+ RegisteredClaims: jwt.RegisteredClaims{ // (3) !
 	 ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // (4) !
 	 Issuer:    "john", // (5) !
 	 Subject:   "subject", // (6) !
-  },
+ },
 }
 
 key = /* Load key from somewhere, for example a file */
@@ -123,7 +123,7 @@ key = /* Load key from somewhere, for example a file */
 t = jwt.NewWithClaims(jwt.SigningMethodES256, claims) // (7)!
 s = t.SignedString(key) // (8)!
 ```
-1. This initializes claims variable based of the type CustomClaims struct as declared. This will have all defintions and values for the custom claims along with the registered claim values embedded via[`jwt.RegisteredClaims`] (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1).
+1. This initializes claims variable based of the type CustomClaims struct as declared. This will have all definitions and values for the custom claims along with the registered claim values embedded via[`jwt.RegisteredClaims`] (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1).
 2. The "bar" string here is the actual value for the custom claim Foo. This is completely user-defined and not governed by any JWT standardization, allowing for flexible claim modeling across tokens.
 3. jwt.RegisteredClaims{...} sets standard claims that are recognized across JWT-compliant systems. This may include expiry, issuer, and subject identifiers.
 4. The ExpiresAt field uses jwt.NewNumericDate(...) to convert a Go time.Time into the numeric timestamp format expected in JWTs. Here, the token is valid for 24 hours.

--- a/docs/usage/create.md
+++ b/docs/usage/create.md
@@ -98,24 +98,24 @@ In the above examples Custom Claims have been used with [`jwt.MapClaims`](https:
 
 ```go
 var (
-	key *ecdsa.PrivateKey
-	t   *jwt.Token
-	s   string
-  claims CustomClaims
+ key *ecdsa.PrivateKey
+ t   *jwt.Token
+ s   string
+ claims CustomClaims
 )
 
 type CustomClaims struct {
-	Foo  string `json:"foo"`
-	jwt.RegisteredClaims
+ Foo  string `json:"foo"`
+ jwt.RegisteredClaims
 }
 
 claims := CustomClaims{ // (1)!
-		"bar", // (2) !
-		jwt.RegisteredClaims{ // (3) !
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // (4) !
-			Issuer:    "john", // (5) !
-			Subject:   "subject", // (6) !
-		},
+ "bar", // (2) !
+  jwt.RegisteredClaims{ // (3) !
+	 ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // (4) !
+	 Issuer:    "john", // (5) !
+	 Subject:   "subject", // (6) !
+  },
 }
 
 key = /* Load key from somewhere, for example a file */
@@ -127,8 +127,8 @@ s = t.SignedString(key) // (8)!
 2. The "bar" string here is the actual value for the custom claim Foo. This is completely user-defined and not governed by any JWT standardization, allowing for flexible claim modeling across tokens.
 3. jwt.RegisteredClaims{...} sets standard claims that are recognized across JWT-compliant systems. This may include expiry, issuer, and subject identifiers.
 4. The ExpiresAt field uses jwt.NewNumericDate(...) to convert a Go time.Time into the numeric timestamp format expected in JWTs. Here, the token is valid for 24 hours.
-5. The `"john"` [^iss] value assigned to the Issuer claim helps the recipient validate who issued the token — a critical aspect when tokens are exchanged across systems.
-6. The `"subject"`[^sub] value assigned to Subject identifies the principal for whom the token was issued, often corresponding to the authenticated user.
+5. The `"john"` value assigned to the Issuer[^iss] claim helps the recipient validate who issued the token — a critical aspect when tokens are exchanged across systems.
+6. The `"subject"` value assigned to Subject[^sub] identifies the principal for whom the token was issued, often corresponding to the authenticated user.
 7. This initializes a new [`jwt.Token`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#Token) struct based on the supplied signing method. Here as well an **asymmetric** method is chosen, as the first parameter.
 8. This step computes a cryptographic signature based on the supplied private key.
 

--- a/docs/usage/create.md
+++ b/docs/usage/create.md
@@ -92,6 +92,46 @@ s = t.SignedString(key) // (6)!
 [^iss]: [Section 4.1.1 of RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1)
 [^sub]: [Section 4.1.2 of RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2)
 
+## With Custom Claims
+
+In the above examples Custom Claims have been used with [`jwt.MapClaims`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#MapClaims) type. However, when working with a consistent structure across multiple tokens, it's often cleaner and more maintainable to define your own struct type embedding jwt.RegisteredClaims. This allows for type safety and easier reusablility.
+
+```go
+var (
+	key *ecdsa.PrivateKey
+	t   *jwt.Token
+	s   string
+  claims CustomClaims
+)
+
+type CustomClaims struct {
+	Foo  string `json:"foo"`
+	jwt.RegisteredClaims
+}
+
+claims := CustomClaims{ // (1)!
+		"bar", // (2) !
+		jwt.RegisteredClaims{ // (3) !
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // (4) !
+			Issuer:    "john", // (5) !
+			Subject:   "subject", // (6) !
+		},
+}
+
+key = /* Load key from somewhere, for example a file */
+
+t = jwt.NewWithClaims(jwt.SigningMethodES256, claims) // (7)!
+s = t.SignedString(key) // (8)!
+```
+1. This initializes claims variable based of the type CustomClaims struct as declared. This will have all defintions and values for the custom claims along with the registered claim values embedded via[`jwt.RegisteredClaims`] (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1).
+2. The "bar" string here is the actual value for the custom claim Foo. This is completely user-defined and not governed by any JWT standardization, allowing for flexible claim modeling across tokens.
+3. jwt.RegisteredClaims{...} sets standard claims that are recognized across JWT-compliant systems. This may include expiry, issuer, and subject identifiers.
+4. The ExpiresAt field uses jwt.NewNumericDate(...) to convert a Go time.Time into the numeric timestamp format expected in JWTs. Here, the token is valid for 24 hours.
+5. The `"john"` [^iss] value assigned to the Issuer claim helps the recipient validate who issued the token — a critical aspect when tokens are exchanged across systems.
+6. The `"subject"`[^sub] value assigned to Subject identifies the principal for whom the token was issued, often corresponding to the authenticated user.
+7. This initializes a new [`jwt.Token`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#Token) struct based on the supplied signing method. Here as well an **asymmetric** method is chosen, as the first parameter.
+8. This step computes a cryptographic signature based on the supplied private key.
+
 ## With Options
 
 While we already prepared a


### PR DESCRIPTION
Added an example showing how to define and use custom JWT claims using a struct with embedded jwt.RegisteredClaims.

Closes #6 